### PR TITLE
added bindWithDispatch method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn.lock
 
 # Build bundles
 public/dist/
+
+## VSCode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -195,6 +195,34 @@ state = {
 };
 ```
 
+## Autobind Action Creators
+
+Method to bind a given dispatch function with the passed services. 
+This helps with not having to pass down `store.dispatch` as a prop everywhere the service is being used. Read More: http://redux.js.org/docs/api/bindActionCreators.html
+```js
+import reduxifyServices, { bindWithDispatch } from 'feathers-redux';
+
+// create a services object as described above 
+const rawServices = reduxifyServices(...);
+
+// create a store with rootReducer combining reducers from rawServices
+const store = createStore(...)
+
+// use the bindWithDispatch method to bind rawServices' action creators with store.dispatch
+const services = bindWithDispatch(store.dispatch, rawServices)
+```
+```js
+// before 
+store.dispatch(services.messages.get('557XxUL8PalGMgOo'));
+store.dispatch(services.messages.find());
+store.dispatch(services.messages.create({ text: 'Hello!' }));
+
+// after
+services.messages.get('557XxUL8PalGMgOo');
+services.messages.find();
+services.messages.create({ text: 'Hello!' });
+```
+
 ## Examples
 
 `example/` contains an example you may run. Its README has instructions.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
   },
   "dependencies": {
     "debug": "^2.6.8",
+    "ramda": "^0.24.1",
+    "redux": "^3.7.2",
     "redux-actions": "^2.0.3"
   },
   "devDependencies": {
@@ -68,7 +70,6 @@
     "feathers-tests-fake-app-users": "^1.0.0",
     "istanbul": "1.1.0-alpha.1",
     "mocha": "^3.4.2",
-    "redux": "^3.6.0",
     "redux-promise-middleware": "^4.3.0",
     "redux-thunk": "^2.2.0",
     "semistandard": "^11.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 
 import { createAction, handleActions } from 'redux-actions';
+import { bindActionCreators } from 'redux';
+import { pick, omit, mapObjIndexed } from 'ramda';
 import makeDebug from 'debug';
 
 /**
@@ -309,4 +311,44 @@ export const getServicesStatus = (servicesState, serviceNames) => {
   });
 
   return status;
+};
+
+/**
+ * Method to bind a given dispatch function with the passed services.
+ *
+ * This helps with not having to pass down store.dispatch as a prop everywhere
+ * Read More: http://redux.js.org/docs/api/bindActionCreators.html
+ *
+ * @param {Object} services - using the default reduxifyService method
+ * @param {Function} dispatch - the relevant store.dispatch function which is to be bounded to actionCreators
+ * @param {Array=} targetActions - list of action names to be targeted for binding
+ * @returns {Object} boundServices - returns the new services object with the bounded action creators
+ */
+
+export const bindWithDispatch = (dispatch, services, targetActions) => {
+  targetActions = targetActions || [
+    // default targets from feathers-redux
+    'find',
+    'get',
+    'create',
+    'update',
+    'patch',
+    'remove',
+    'reset',
+    'store',
+    // couple more optional ones in case feathers-reduxify-authentication is being used
+    'authenticate',
+    'logout'
+  ];
+
+  // map over the services object to get every service
+  return mapObjIndexed(val => ({
+
+    //  destructure in bound action creators that are picked
+    ...bindActionCreators(pick(targetActions, val), dispatch),
+
+   // destructure in rest of the keys that were not targeted as action creators
+    ...omit(targetActions, val)
+  }))(services);
+
 };


### PR DESCRIPTION
Closes https://github.com/feathersjs/feathers-redux/issues/21

## Autobind Action Creators

Method to bind a given dispatch function with the passed services. 
This helps with not having to pass down `store.dispatch` as a prop everywhere the service is being used. Read More: http://redux.js.org/docs/api/bindActionCreators.html
```js
import reduxifyServices, { bindWithDispatch } from 'feathers-redux';

// create a services object as described in the readme
const rawServices = reduxifyServices(...);

// create a store with rootReducer combining reducers from rawServices
const store = createStore(...)

// use the bindWithDispatch method to bind rawServices' action creators with store.dispatch
const services = bindWithDispatch(store.dispatch, rawServices)
```
```js
// before 
store.dispatch(services.messages.get('557XxUL8PalGMgOo'));
store.dispatch(services.messages.find());
store.dispatch(services.messages.create({ text: 'Hello!' }));

// after
services.messages.get('557XxUL8PalGMgOo');
services.messages.find();
services.messages.create({ text: 'Hello!' });
```