### PR TITLE
Export action types

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ The default is
     get(id, params) {},
     store(object) {}, // Interface for realtime replication.
     reset() {}, // Reinitializes store for this service.
+    // action types
+    types: {
+      RESET: 'RESET',
+      STORE: 'STORE',
+      SERVICES_MESSAGES_FIND: 'SERVICES_MESSAGES_FIND',
+      SERVICES_MESSAGES_FIND_PENDING: 'SERVICES_MESSAGES_FIND_PENDING',
+      SERVICES_MESSAGES_FIND_FULFILLED: 'SERVICES_MESSAGES_FIND_FULFILLED',
+      SERVICES_MESSAGES_FIND_REJECTED: 'SERVICES_MESSAGES_FIND_REJECTED',
+      // same for all methods GET, CREATE...
+    },
     // reducer
     reducer() {}, // Reducers handling actions MESSAGES_CREATE_PENDING, _FULFILLED, and _REJECTED.
   },
@@ -116,6 +126,13 @@ combineReducers({
 
 > **ProTip:** You have to include `redux-promise-middleware` and `redux-thunk`
 in your middleware.
+
+You may listen to actions dispatched by `feathers-redux`, for example to manage your side-effects. With `redux-saga`, it would be done with:
+```javascript
+yield take(services.users.types.SERVICES_USERS_CREATE_FULFILLED, function*(action) {
+  // do something when user gets created
+});
+```
 
 ## Documentation: getServicesStatus
 

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,13 @@ const reduxifyService = (app, route, name = route, options = {}) => {
   const RESET = `${SERVICE_NAME}RESET`;
   const STORE = `${SERVICE_NAME}STORE`;
 
+  const actionTypesForServiceMethod = (actionType) => ({
+    [`${actionType}`]: `${actionType}`,
+    [`${actionType}_${opts.PENDING}`]: `${actionType}_${opts.PENDING}`,
+    [`${actionType}_${opts.FULFILLED}`]: `${actionType}_${opts.FULFILLED}`,
+    [`${actionType}_${opts.REJECTED}`]: `${actionType}_${opts.REJECTED}`,
+  });
+
   return {
     // ACTION CREATORS
     // Note: action.payload in reducer will have the value of .data below
@@ -161,6 +168,19 @@ const reduxifyService = (app, route, name = route, options = {}) => {
     reset: createAction(RESET),
     store: createAction(STORE, store => store),
     on: (event, data, fcn) => (dispatch, getState) => { fcn(event, data, dispatch, getState); },
+
+    // ACTION TYPES
+
+    types: {
+      ...actionTypesForServiceMethod(FIND),
+      ...actionTypesForServiceMethod(GET),
+      ...actionTypesForServiceMethod(CREATE),
+      ...actionTypesForServiceMethod(UPDATE),
+      ...actionTypesForServiceMethod(PATCH),
+      ...actionTypesForServiceMethod(REMOVE),
+      RESET,
+      STORE,
+    },
 
     // REDUCER
 


### PR DESCRIPTION
### Summary

This PR exports all the action types used by the reduxified services, and put them in the `types` field.

```js
const services = reduxifyServices(app, ['messages']);
console.log(services.types);

// Will output:
{
  SERVICES_MESSAGES_FIND: 'SERVICES_MESSAGES_FIND',
  SERVICES_MESSAGES_FIND_PENDING: 'SERVICES_MESSAGES_FIND_PENDING',
  SERVICES_MESSAGES_FIND_FULFILLED: 'SERVICES_MESSAGES_FIND_FULFILLED',
  SERVICES_MESSAGES_FIND_REJECTED: 'SERVICES_MESSAGES_FIND_REJECTED',
 // ... same for CREATE, GET etc
}
```

### Why is this useful?

In some apps, it might be useful to listen to actions dispatched by feathers-redux, for example for managing side-effects.

Right now, to listen to actions dispatched by feathers-redux, we listen to the string directly. An example with redux-saga would be: `yield take('SERVICES_MESSAGES_CREATE_FULFILLED', doSomethingSaga);`

After this PR, it would be `yield take(services.types.SERVICES_MESSAGES_CREATE_FULFILLED, doSomethingSaga)`

The big advantage is to avoid putting raw strings everywhere in the code (bad practice).

### Other Information

If this is useful, I'll update some docs too.