### PR TITLE
Data key not set to null before promise resolves or rejects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
         [opts.isLoading]: ifLoading,
         [opts.isSaving]: !ifLoading,
         [opts.isFinished]: false,
-        [opts.data]: null,
+        [opts.data]: state[opts.data] || null,
         [opts.queryResult]: state[opts.queryResult] || null //  leave previous to reduce redraw
       });
     },
@@ -153,7 +153,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
     [`${actionType}`]: `${actionType}`,
     [`${actionType}_${opts.PENDING}`]: `${actionType}_${opts.PENDING}`,
     [`${actionType}_${opts.FULFILLED}`]: `${actionType}_${opts.FULFILLED}`,
-    [`${actionType}_${opts.REJECTED}`]: `${actionType}_${opts.REJECTED}`,
+    [`${actionType}_${opts.REJECTED}`]: `${actionType}_${opts.REJECTED}`
   });
 
   return {
@@ -179,7 +179,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
       ...actionTypesForServiceMethod(PATCH),
       ...actionTypesForServiceMethod(REMOVE),
       RESET,
-      STORE,
+      STORE
     },
 
     // REDUCER
@@ -360,16 +360,13 @@ export const bindWithDispatch = (dispatch, services, targetActions) => {
     'logout'
   ];
 
-
   const _serviceNames = Object.keys(services);
   // map over the services object to get every service
   _serviceNames.forEach(_name => {
-
     const _methodNames = Object.keys(services[_name]);
 
     // map over every method in the service
     _methodNames.forEach(_method => {
-
       // if method is in targeted actions then replace it with bounded method
       if (targetActions.includes(_method)) {
         services[_name][_method] = bindActionCreators(

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -71,6 +71,23 @@ describe('reduxify:reducer - array of paths', () => {
     });
   });
 
+  ['find', 'get', 'create', 'update', 'patch', 'remove'].forEach(method => {
+    describe(`does not change data for ${method}`, () => {
+      ['pending'].forEach(step => {
+        it(`for ${step}`, () => {
+          var validStates = getValidStates(false, false, false, true);
+          if (method === 'find') { validStates = getValidStates(true, true, false, true); }
+          if (method === 'get') { validStates = getValidStates(true, false, false, true); }
+
+          const state = services.users.reducer(
+            { data: { a: 'a' }, queryResult: null }, reducerActionType(method, step)
+          );
+          assert.deepEqual(state, validStates[step]);
+        });
+      });
+    });
+  });
+
   describe('for reset', () => {
     it('resets state', () => {
       const state = services.users.reducer({}, services.users.reset());
@@ -217,8 +234,9 @@ function reducerActionType (method, step) {
   };
 }
 
-function getValidStates (ifLoading, isFind, haveQueryResult) {
+function getValidStates (ifLoading, isFind, haveQueryResult, haveDataResult) {
   const qr = haveQueryResult ? [{ a: 'a' }] : null;
+  const dr = haveDataResult ? { a: 'a' } : null;
 
   return {
     pending: {
@@ -226,7 +244,7 @@ function getValidStates (ifLoading, isFind, haveQueryResult) {
       isLoading: ifLoading,
       isSaving: !ifLoading,
       isFinished: false,
-      data: null,
+      data: dr,
       queryResult: qr
 
     },


### PR DESCRIPTION
When saving/loading the data key used to be set to null, I have changed this to leave the data key as is until the promise is resolved or rejected where it will continue with the existing behaviour: 

On resolved the data key will be set with action.payload or null if it's a find.
On rejected the data key will be set to null.

This change will stop data from flashing out for a sec whilst waiting to get a result back.

I started a discussion on this here: https://github.com/feathersjs/feathers-redux/issues/31

I have run tests and everything is fine. There are a few lint fixes that I've included in this PR.