### PR TITLE
Move redux to peerDependencies (#54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lib": "lib"
   },
   "peerDependencies": {
-    "redux": "*",
+    "redux": "*"
   },
   "dependencies": {
     "debug": "^2.6.8",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,11 @@
   "directories": {
     "lib": "lib"
   },
+  "peerDependencies": {
+    "redux": "*",
+  },
   "dependencies": {
     "debug": "^2.6.8",
-    "redux": "^3.7.2",
     "redux-actions": "^2.0.3"
   },
   "devDependencies": {
@@ -69,6 +71,7 @@
     "feathers-tests-fake-app-users": "^1.0.0",
     "istanbul": "1.1.0-alpha.1",
     "mocha": "^3.4.2",
+    "redux": "^3.7.2",
     "redux-promise-middleware": "^4.3.0",
     "redux-thunk": "^2.2.0",
     "semistandard": "^11.0.0",


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving.

Redux gets bundled twice (wasting precious, precious bundle size bytes) if you use Redux v4 in your project, while also importing this project.

- [x] Are there any open issues that are related to this?

#54.

- [x] Is this PR dependent on PRs in other repos?

Nope.

This is a breaking change, since it will now require users to explicitly state a version of redux to their package.json to be included. Most people using this package are probably using redux in their projects anyways... but to be safe, a major version bump is appropriate, even though none of the APIs are changing.
